### PR TITLE
Handle WorkshopFileInfos.json

### DIFF
--- a/src/tts_tools/libtts.py
+++ b/src/tts_tools/libtts.py
@@ -175,4 +175,9 @@ def get_save_name(filename):
 
     with open(filename, 'r', encoding='utf-8') as infile:
         save = json.load(infile)
+
+    # Handle possible WorkshopFileInfos.json
+    if isinstance(save, list):
+        return None
+
     return save["SaveName"]

--- a/src/tts_tools/prefetch/__init__.py
+++ b/src/tts_tools/prefetch/__init__.py
@@ -36,6 +36,11 @@ def prefetch_file(filename,
 
     try:
         save_name = get_save_name(filename)
+        if save_name is None:
+            print("Skipping {filename} likely workshop file info".format(
+                filename=filename
+            ))
+            return
     except Exception:
         save_name = "???"
 


### PR DESCRIPTION
Allow running `tts-prefetch ~/Library/Tabletop\ Simulator/Mods/Workshop/*.json` without an error.   

I generally just run the prefetch on my entire mods directory and it always errors out on the WorkshopFileinfos.json file

Example output:
```
Skipping /Users/user.home/Library/Tabletop Simulator/Mods/Workshop/WorkshopFileInfos.json likely workshop file info
```
