### PR TITLE
Fixing url to png or jpg conversion bugs

### DIFF
--- a/src/tts_tools/libtts.py
+++ b/src/tts_tools/libtts.py
@@ -141,13 +141,19 @@ def get_fs_path(path, url):
     elif is_image(path, url):
         # TTS appears to perform some weird heuristics when determining
         # the file suffix. ._.
+        png_filename = recoded_name + ".png"
+        png_fullPath = os.path.join(IMGPATH, png_filename)
+        jpg_filename = recoded_name + ".jpg"
+        jpg_fullPath = os.path.join(IMGPATH, jpg_filename)
+        if os.path.isfile(png_fullPath):
+            return png_fullPath
+        elif os.path.isfile(jpg_fullPath):
+            return jpg_fullPath
+        
         if url.find(".png") > 0:
-            file_suffix = ".png"
+            return png_fullPath
         else:
-            file_suffix = ".jpg"
-        filename = recoded_name + file_suffix
-        return os.path.join(IMGPATH, filename)
-
+            return jpg_fullPath
     else:
         errstr = (
             "Do not know how to generate path for "

--- a/src/tts_tools/prefetch/__init__.py
+++ b/src/tts_tools/prefetch/__init__.py
@@ -144,6 +144,18 @@ def prefetch_file(
             done.add(url)
             continue
 
+        if outfile_name.endswith('.png'):
+            jpg_path = os.path.splitext(outfile_name)[0] + '.jpg'
+            if os.path.isfile(jpg_path) and not refetch:
+                done.add(url)
+                continue
+
+        if outfile_name.endswith('.jpg'):
+            jpg_path = os.path.splitext(outfile_name)[0] + '.png'
+            if os.path.isfile(jpg_path) and not refetch:
+                done.add(url)
+                continue
+
         print("{} ".format(url), end="", flush=True)
 
         if dry_run:
@@ -187,6 +199,11 @@ def prefetch_file(
         print(size_msg, end="", flush=True)
 
         content_type = response.getheader("Content-Type", "").strip()
+        if content_type == "image/jpeg" or content_type == "image/jpg":
+            outfile_name = os.path.splitext(outfile_name)[0] + '.jpg'
+        if content_type == "image/png":
+            outfile_name = os.path.splitext(outfile_name)[0] + '.png'
+
         is_expected = not content_type or content_expected(content_type)
         if not (is_expected or ignore_content_type):
             print_err(


### PR DESCRIPTION
Nice tool but when comparing to the game and TTS Mod Backup on Nexus, it doesn't always figure out correctly if a URL is a PNG or JPG.  

This PR fixes the issues I found by using the content type header to figure out which type it is.
and then looks for both files in order to backup.

I tested with:
https://steamcommunity.com/sharedfiles/filedetails/?id=1686824824
which has a set of jpgs and pngs images.

For example, 
http://cloud-3.steamusercontent.com/ugc/1000268739968105278/2E183FDC5E647428A96F0F739406794A7CAA4F33/
and 
http://i.imgur.com/g1M6tbY.jpg
are both jpg files which prior, it incorrectly thinks they are png files.
